### PR TITLE
UX: Adjust styles for long words

### DIFF
--- a/app/services/discourse_rewind/rewind/action/top_words.rb
+++ b/app/services/discourse_rewind/rewind/action/top_words.rb
@@ -7,7 +7,7 @@ module DiscourseRewind
         { word: "what", score: 100 },
         { word: "have", score: 90 },
         { word: "you", score: 80 },
-        { word: "achieved", score: 70 },
+        { word: "overachieved", score: 70 },
         { word: "this", score: 60 },
         { word: "week", score: 50 },
       ],

--- a/assets/javascripts/discourse/components/reports/top-words/word-card.gjs
+++ b/assets/javascripts/discourse/components/reports/top-words/word-card.gjs
@@ -3,6 +3,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { htmlSafe } from "@ember/template";
+import concatClass from "discourse/helpers/concat-class";
 import emoji from "discourse/helpers/emoji";
 import discourseLater from "discourse-common/lib/later";
 
@@ -45,6 +46,10 @@ export default class WordCard extends Component {
     };
   }
 
+  get longWord() {
+    return this.args.word.length >= 7;
+  }
+
   get cardStyle() {
     return htmlSafe(`${this.randomStyle}; ${this.mysteryData.color};`);
   }
@@ -72,7 +77,10 @@ export default class WordCard extends Component {
     <div
       {{on "click" this.handleClick}}
       {{on "mouseleave" this.handleLeave}}
-      class="rewind-card__wrapper"
+      class={{concatClass
+        "rewind-card__wrapper"
+        (if this.longWord "-long-word")
+      }}
       style={{this.cardStyle}}
       {{didInsert this.registerCardContainer}}
       role="button"

--- a/assets/stylesheets/common/top-words.scss
+++ b/assets/stylesheets/common/top-words.scss
@@ -137,6 +137,16 @@
         0 0 / 6px 6px,
       var(--secondary-low);
   }
+  &.-long-word .rewind-card__title {
+    font-size: var(--font-0);
+  }
+  &.-long-word .rewind-card {
+    padding: 2px;
+  }
+  .rewind-card__title {
+    overflow-wrap: anywhere;
+    hyphens: auto;
+  }
   .rewind-card__image {
     image-rendering: pixelated;
   }


### PR DESCRIPTION
This PR adds a class to the word cards if a word is 7 characters in length or larger. This allows lowering the font size in order to prevent overflow & odd hyphenation.

**After**
![CleanShot 2025-01-14 at 11 31 15@2x](https://github.com/user-attachments/assets/c338abe1-fd1a-4618-9c4e-3eb528836270)

**Before**
![CleanShot 2025-01-14 at 11 33 04@2x](https://github.com/user-attachments/assets/01650a51-3bfc-48dd-98ea-f25bd3cbddb7)
